### PR TITLE
20 links on vikrants page are not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor
 .idea
 .vscode/settings.json
 _site/feed.xml
+tasks.md

--- a/_layouts/fellow.liquid
+++ b/_layouts/fellow.liquid
@@ -51,6 +51,10 @@ layout: default
           <div class="contact-label">ORCID:</div>
           <div class="contact-value"><a href="https://orcid.org/{{ page.orcid }}" target="_blank">{{ page.orcid }}</a></div>
         {% endif %}
+        {% if page.Github %}
+          <div class="contact-label">Github: </div>
+          <div class="contact-value"><a href="{{ page.Github }}" target="_blank"> {{ page.Github }} </a></div>
+        {% endif %}
         {% if page.other %}
           <div class="contact-label">Other:</div>
           <div class="contact-value">{{ page.other }}</div>

--- a/_projects/HovakimGrabski.md
+++ b/_projects/HovakimGrabski.md
@@ -8,10 +8,10 @@ importance: 3
 category: "🎓 Cohort 2024"
 fellow-type: "Faculty Fellow"
 related_publications: false
-voice: "(123) 456-7890"
-email: "hovakim@example.edu"
-orcid: "0000-0002-1234-5678"
-other: "Office hours by appointment." 
+voice:
+email:
+orcid:
+other:
 outcomes: 
     - "educational aids" 
 ---

--- a/_projects/MatthewMcCoy.md
+++ b/_projects/MatthewMcCoy.md
@@ -8,8 +8,7 @@ importance: 3
 category: "🎓 Cohort 2025"
 fellow-type: ""
 related_publications: false
-contact: 
-    - Email: m3mccoy@ucsd.edu
+email: m3mccoy@ucsd.edu
 ---
 
 Matt is a former Network Engineer who switched to Linux Administration in 2010. Since then he has worked at a biological science nonprofit, a corporate enterprise company, Canonical (makers of Ubuntu Linux), and now UCSD. Matt joined the CIP Fellowship program in early 2025.

--- a/_projects/VikrantTripathy.md
+++ b/_projects/VikrantTripathy.md
@@ -9,7 +9,8 @@ category: "🎓 Cohort 2025"
 fellow-type: ""
 related_publications: false
 email: vtripathy@ucsd.edu
-LinkedIn: www.linkedin.com/in/vtripath/
+LinkedIn: https://www.linkedin.com/in/vtripath/
+Github: https://github.com/vtripath65
 orcid: 0000-0002-3246-0680
 ---
 


### PR DESCRIPTION
The issue is fixed now. 
- I added a `https://` prefix to links so that Jekyll does not treat them as relative links 
- I went through all of the fellows' pages to make updates to typos "Email" instead of "email" etc. as well. 