### PR TITLE
Individual fellow pages have the correct summaries

### DIFF
--- a/_layouts/fellow.liquid
+++ b/_layouts/fellow.liquid
@@ -71,33 +71,32 @@ layout: default
     </article>
   </div>
 
-  <hr class="my-4 fellow-divider"> 
+  <hr class="my-4 fellow-divider">
 
-  {% if page.outcomes %}
+  {% assign my_outcomes = site.outcomes | where: "fellow", page.title %}
+  {% if my_outcomes and my_outcomes.size > 0 %}
     <div class="fellow-outcomes-list">
-      {% for outcome_slug in page.outcomes %}
-        <a href="/outcomes/{{ outcome_slug | slugify }}/" style="text-decoration: none; color: inherit;">
+      {% for o in my_outcomes %}
+        <a href="{{ o.url }}" style="text-decoration: none; color: inherit;">
           <div class="fellow-outcome hover-card">
-            <h3 class="post-title"> {{ outcome_slug | capitalize }} </h3>
-            {%  comment  %} Working up to here. page.outcomes.tags not working {% endcomment %}
-            {% if page.outcomes.summary %}
-              <p style="padding-bottom: 0px; margin-bottom: 0px;"> {{ page.outcomes.summary }} </p>
+            <h3 class="post-title">{{ o.title }}</h3>
+            {% if o.summary %}
+              <p style="padding-bottom: 0; margin-bottom: 0;">{{ o.summary }}</p>
             {% endif %}
-            {% if page.outcomes.tags %}
+            {% if o.tags %}
               <br>
-              {% if page.outcomes.tags %}
-                <p class="post-tags outcome" style="padding-bottom: 0px; margin-bottom: 0px;">
-                {% for t in page.outcomes.tags %}
+              <p class="post-tags outcome" style="padding-bottom: 0; margin-bottom: 0;">
+                {% for t in o.tags %}
                   <a class="tag-pill" href="/outcomes/tag/{{ t | uri_escape }}/"># {{ t }}</a>
                 {% endfor %}
-                </p>
-              {% endif %}
+              </p>
             {% endif %}
           </div>
         </a>
       {% endfor %}
     </div>
   {% endif %}
+
 
   {% if page.related_publications %}
     <h2 class="mt-5">References</h2>

--- a/_outcomes/software-container.md
+++ b/_outcomes/software-container.md
@@ -1,7 +1,7 @@
 ---
 layout: outcome-project
 title: "Containerizing FourCastNet for Kubernetes Cluster"
-fellow: "Henri Li" 
+fellow: "Henry Li" 
 summary: Researchers at San Diego State University wanted more computation power to train and run inference on FourCastNet.
 url: "https://hub.docker.com/repository/docker/henrylisdsu/nvidia-cuda-12.4/general" 
 format: "docker" 


### PR DESCRIPTION
The fellow summaries are working now. We filter based on the `.fellow` attribute for each project, so that only each fellow's projects are loaded and listed. 
The summaries follow the same classes and setup as on the Outcomes page, so changes in CSS should affect both versions of the display. 
At the moment I do not believe this will scale to multiple fellows on a single Outcome. 