### PR TITLE
Updates to tag UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor
 .vscode/settings.json
 _site/feed.xml
 tasks.md
+_layouts/scratch

--- a/_layouts/outcome-tag.liquid
+++ b/_layouts/outcome-tag.liquid
@@ -1,7 +1,47 @@
 ---
-layout: page
+layout: default
 ---
 
+<div class="container mt-5" role="main"> 
+    <div class="post"> 
+        <header class="post-header"> 
+            <h1 class="post-title">
+                <i class="fa-solid fa-hashtag fa-sm"></i>
+                 {{ page.title }}
+                </h1> 
+                <p class="post-description">
+                    an archive of posts with this tag
+                </p> 
+            </header> 
+            {% assign matches = site.outcomes | where_exp: "o", "o.tags contains page.title" %}
+            <article class="archive"> 
+                <div class="table-responsive"> 
+                  {% if matches %}
+                    <table class="table table-sm table-borderless"> 
+                        <tbody>
+                          {% for o in matches %}
+                            <tr> 
+                                <th scope="row">
+                                    {{ o.date | date: "%b %-d, %Y" }}
+                                </th> 
+                                <td> 
+                                    <a class="post-link" href="{{ o.url | relative_url }}">
+                                        {{ o.title }}
+                                    </a> 
+                                </td> 
+                            </tr> 
+                          {% endfor %}
+                        </tbody>
+                    </table> 
+                  {% endif %}
+                </div> 
+            </article> 
+        </div> 
+    </div>
+</div>
+
+
+{% comment %}
 <h1>Outcomes tagged “{{ page.title }}”</h1>
 
 <ul class="archive-list">
@@ -19,3 +59,4 @@ layout: page
     <li>No outcomes found under this tag.</li>
   {% endif %}
 </ul>
+{% endcomment %}


### PR DESCRIPTION
The outcomes tags now look like the existing tag view on the blog.

The for loop logic has not been tested, as no existing tag is used on more than one outcome. 